### PR TITLE
Fail on missing snapshot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.3.0 (2023-12-01)
+
+* feat: improve error messages ([5d622bc](https://github.com/bmihelac/pytest-image-snapshot/commit/5d622bc))
+
 ## 0.2.2 (2023-12-01)
 
 * fix: default threshold should not be None ([470c4b0](https://github.com/bmihelac/pytest-image-snapshot/commit/470c4b0))

--- a/README.md
+++ b/README.md
@@ -87,6 +87,14 @@ Use the `--image-snapshot-update` flag to update or create new reference snapsho
 pytest --image-snapshot-update
 ```
 
+### Failing when snapshots are missing (`--image-snapshot-fail-if-missing`)
+
+Use the `--image-snapshot-fail-if-missing` flag to fail the test when the snapshot is missing. This is particularly useful in CI check to ensure that all snapshots are present and up-to-date.
+
+```bash
+pytest --image-snapshot-fail-if-missing
+```
+
 ## Example
 
 Visual regression test for [Django](https://www.djangoproject.com/) application home page with [playwright](https://playwright.dev/python/docs/intro):

--- a/pytest_image_snapshot.py
+++ b/pytest_image_snapshot.py
@@ -79,8 +79,15 @@ def image_snapshot(request):
                     if config.option.verbose > 1:
                         src_image.show(title="original")
                         img.show(title="new")
+                verbose_msg = (
+                    " Use -v or -vv to display diff."
+                    if not config.option.verbose
+                    else ""
+                )
+                snapshot_update_msg = " Use --image-snapshot-update to update snapshot."
                 raise ImageMismatchError(
-                    f"Image does not match the snapshot stored in {img_path}"
+                    f"Image does not match the snapshot stored in {img_path}."
+                    f"{verbose_msg}{snapshot_update_msg}"
                 )
             else:
                 return

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ def read(fname):
 
 setup(
     name='pytest-image-snapshot',
-    version='0.2.2',
+    version='0.3.0',
     author='Bojan Mihelac',
     author_email='bojan@informatikamihelac.com',
     maintainer='Bojan Mihelac',


### PR DESCRIPTION
Add new `--image-snapshot-fail-if-missing`, particularly useful in CI. Fixes #1 🚀 