### PR TITLE
 Add --image-snapshot-save-diff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.3.0 (2023-12-01)
+
+* feat: improve error messages ([5d622bc](https://github.com/bmihelac/pytest-image-snapshot/commit/5d622bc))
+
 ## 0.2.2 (2023-12-01)
 
 * fix: default threshold should not be None ([470c4b0](https://github.com/bmihelac/pytest-image-snapshot/commit/470c4b0))

--- a/README.md
+++ b/README.md
@@ -79,6 +79,14 @@ The verbose mode enhances the output detail for `image_snapshot` tests:
 
 This feature assists in quickly identifying and analyzing visual differences during test failures.
 
+### Save actual image and diff image (`--image-snapshot-save-diff`)
+
+Use the `--image-snapshot-save-diff` flag to save the actual image and the diff image when there's a mismatch. This is particularly useful for debugging in a CI environment.
+
+```bash
+pytest --image-snapshot-save-diff
+```
+
 ### Updating Snapshots (`--image-snapshot-update`)
 
 Use the `--image-snapshot-update` flag to update or create new reference snapshots. This is useful for incorporating intentional visual changes into your tests, ensuring that your snapshots always reflect the current expected state.

--- a/README.md
+++ b/README.md
@@ -87,6 +87,14 @@ Use the `--image-snapshot-update` flag to update or create new reference snapsho
 pytest --image-snapshot-update
 ```
 
+### Failing when snapshots are missing (`--image-snapshot-fail-if-missing`)
+
+Use the `--image-snapshot-fail-if-missing` flag to fail the test when the snapshot is missing. This is particularly useful in CI check to ensure that all snapshots are present and up-to-date.
+
+```bash
+pytest --image-snapshot-fail-if-missing
+```
+
 ## Example
 
 Visual regression test for [Django](https://www.djangoproject.com/) application home page with [playwright](https://playwright.dev/python/docs/intro):

--- a/pytest_image_snapshot.py
+++ b/pytest_image_snapshot.py
@@ -79,8 +79,15 @@ def image_snapshot(request):
                     if config.option.verbose > 1:
                         src_image.show(title="original")
                         img.show(title="new")
+                verbose_msg = (
+                    " Use -v or -vv to display diff."
+                    if not config.option.verbose
+                    else ""
+                )
+                snapshot_update_msg = " Use --image-snapshot-update to update snapshot."
                 raise ImageMismatchError(
-                    f"Image does not match the snapshot stored in {img_path}"
+                    f"Image does not match the snapshot stored in {img_path}."
+                    f"{verbose_msg}{snapshot_update_msg}"
                 )
             else:
                 return

--- a/pytest_image_snapshot.py
+++ b/pytest_image_snapshot.py
@@ -22,6 +22,11 @@ def pytest_addoption(parser):
         action="store_true",
         help="Fail if snapshot is missing, useful in CI",
     )
+    parser.addoption(
+        "--image-snapshot-save-diff",
+        action="store_true",
+        help="Save actual image and diff next to the snapshot, useful in CI",
+    )
 
 
 def extend_to_match_size(img1, img2):
@@ -60,6 +65,7 @@ def image_snapshot(request):
         config = request.config
         update_snapshots = config.getoption("--image-snapshot-update")
         fail_if_missing = config.getoption("--image-snapshot-fail-if-missing")
+        save_diff = config.getoption("--image-snapshot-save-diff")
 
         img_path = Path(img_path)
         if not update_snapshots and img_path.exists():
@@ -84,6 +90,9 @@ def image_snapshot(request):
                     )
                     if not mismatch:
                         return
+                if save_diff:
+                    diff.save(img_path.with_suffix(".diff" + img_path.suffix))
+                    img.save(img_path.with_suffix(".new" + img_path.suffix))
                 if config.option.verbose:
                     diff.show(title="diff")
                     if config.option.verbose > 1:

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ def read(fname):
 
 setup(
     name='pytest-image-snapshot',
-    version='0.2.2',
+    version='0.3.0',
     author='Bojan Mihelac',
     author_email='bojan@informatikamihelac.com',
     maintainer='Bojan Mihelac',

--- a/tests/test_image_snapshot.py
+++ b/tests/test_image_snapshot.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from pathlib import Path
 import pytest
 
 from PIL import Image
@@ -44,6 +45,27 @@ def test_image_snapshot_fixture(pytester, test_image):
     )
 
     assert result.ret == 0
+
+
+def test_image_snapshot_fixture_save_diff(pytester, test_image):
+    pytester.makepyfile(
+        """
+        from pathlib import Path
+        from PIL import Image
+        import pytest
+
+        def test_different_image(image_snapshot):
+            image = Image.new('RGB', (150, 150), 'white')
+            with pytest.raises(AssertionError):
+                image_snapshot(image, "white.png")
+    """
+    )
+
+    result = pytester.runpytest("--image-snapshot-save-diff")
+
+    result.assert_outcomes(passed=1)
+    assert Path("white.diff.png").exists()
+    assert Path("white.new.png").exists()
 
 
 def test_image_snapshot_fixture_fail_on_missing(pytester):


### PR DESCRIPTION
Ok since now we're _clearly_ friends, I've another one to propose.

In my setup, I run the tests mainly in CI. My main use of snapshot testing is to do dependabot updates confidently.
Now, when a test fail, I must rerun it in local to see the diff... Which is still not right because I'm sadly not on Linux and browsers run different.

With the proposed change, I could simply save all snapshot in one directory and mark it as "artifacts" on failure. Upon failure, I'll be able to check the snapshot directly and easily push the necessary changes.

NOTE: I based this change on the previous one. To review, check the latest commit in this branch